### PR TITLE
Rename app: Change app name to "GoGit"

### DIFF
--- a/composeApp/src/androidMain/res/values/strings.xml
+++ b/composeApp/src/androidMain/res/values/strings.xml
@@ -1,3 +1,3 @@
 <resources>
-    <string name="app_name">GoGit-KMP</string>
+    <string name="app_name">GoGit</string>
 </resources>


### PR DESCRIPTION
The app name was changed from "GoGit-KMP" to "GoGit" in the Android string resources.